### PR TITLE
Update download description to 2.1.4 in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,7 +144,7 @@ circle.attr(<i>"stroke"</i>, <i>"#fff"</i>);</code>
             <div id="column-2">
                 <ul id="aside">
                     <li id="download">
-                        <h2><a href="//github.com/DmitryBaranovskiy/raphael/raw/master/raphael-min.js" title="Minified Library Code"><span>&nbsp;</span>Download v.&nbsp;2.0.0 (82&nbsp;Kb)</a></h2>
+                        <h2><a href="//github.com/DmitryBaranovskiy/raphael/raw/master/raphael-min.js" title="Minified Library Code"><span>&nbsp;</span>Download v.&nbsp;2.1.4 (93&nbsp;Kb)</a></h2>
                         <p>
                             Our recommendation is to <abbr title="GNU ZIP">GZIP</abbr> it. It will help to reduce file size to&nbsp;<strong>20&nbsp;Kb</strong>.
                         </p>


### PR DESCRIPTION
The download link
https://github.com/DmitryBaranovskiy/raphael/raw/master/raphael-min.js
currently points to 2.1.4 but the description used older version.
This commit updates the version and size in kilobytes of the download.
